### PR TITLE
fix: Init to prevent nil errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# OhLeMatt's Fork
+Current repo forked from MiniFalafel. For some reasons, it was impossible to run Premake5 with 
+MiniFalafel's code at the moment (06/11/2024). 
+Maybe it is due to my configuration or my lack of knowledge on Lua/Premake addons, but I had to 
+move some variable initialization to prevent nil errors.
+
+If there is a way to make it work natively with the MiniFalafel's repo (now or in the future), I
+naturally will close this fork (to avoid having many duplicates of this work).
+
 # premake-vscode
 An extension for premake that adds project and workspace generation for Visual Studio Code.
 

--- a/vscode.lua
+++ b/vscode.lua
@@ -1,5 +1,7 @@
 -- VSCODE MODULE
 
+-- Initialize vscode
+premake.modules.vscode = { _VERSION = "1.0.0" }
 
 -- Include workspace and project files
 
@@ -14,8 +16,6 @@ include("_preload.lua")
 local p = premake
 local project = p.project
 local vscode = p.modules.vscode
-
-vscode = { _VERSION = "1.0.0" }
 
 -- Workspace Generation
 function vscode.generateWorkspace(wks)

--- a/vscode_tasks.lua
+++ b/vscode_tasks.lua
@@ -3,10 +3,11 @@
 -- Aliases
 local p = premake
 local vscode = p.modules.vscode
+
+-- Initialize tasks
+vscode.tasks = {}
 local tasks = vscode.tasks
 
--- Define tasks object
-vscode.tasks = {}
 
 -- Task build functions
 function tasks.buildSolutionTask(wks)


### PR DESCRIPTION
# Description
Minimal changes to prevent nil errors.

# Changes
- Move `vscode` init to be earlier in vscode.lua.
- Move `tasks` init to be earlier in vscode_tasks.lua.